### PR TITLE
Change profile endpoint to identify the user by the email claim

### DIFF
--- a/Source/ApiGWs/Tailwind.Traders.Bff/Controllers/ProfilesController.cs
+++ b/Source/ApiGWs/Tailwind.Traders.Bff/Controllers/ProfilesController.cs
@@ -40,14 +40,14 @@ namespace Tailwind.Traders.MobileBff.Controllers
             return Ok(profiles);
         }
 
-        // GET: v1/profiles/id
-        [HttpGet("{userId}")]
+        // GET: v1/profiles/me
+        [HttpGet("me")]
         [ProducesResponseType((int)HttpStatusCode.OK)]
-        public async Task<IActionResult> GetProfile(int userId)
+        public async Task<IActionResult> GetProfile()
         {
             var client = _httpClientFactory.CreateClient(HttpClients.ApiGW);
 
-            var result = await client.GetStringAsync(API.Profiles.GetProfile(_settings.ProfileApiUrl, VERSION_API, userId));
+            var result = await client.GetStringAsync(API.Profiles.GetProfile(_settings.ProfileApiUrl, VERSION_API));
             var profile = JsonConvert.DeserializeObject<Profile>(result);
 
             result = await client.GetStringAsync(API.Coupons.GetCoupons(_settings.CouponsApiUrl, VERSION_API));
@@ -65,14 +65,14 @@ namespace Tailwind.Traders.MobileBff.Controllers
             return Ok(aggresponse);
         }
 
-        // GET: v1/profiles/navbar/id
-        [HttpGet("navbar/{userId}")]
+        // GET: v1/profiles/navbar/me
+        [HttpGet("navbar/me")]
         [ProducesResponseType((int)HttpStatusCode.OK)]
-        public async Task<IActionResult> GetProfileNavBar(int userId)
+        public async Task<IActionResult> GetProfileNavBar()
         {
             var client = _httpClientFactory.CreateClient(HttpClients.ApiGW);
 
-            var result = await client.GetStringAsync(API.Profiles.GetProfile(_settings.ProfileApiUrl, VERSION_API, userId));
+            var result = await client.GetStringAsync(API.Profiles.GetProfile(_settings.ProfileApiUrl, VERSION_API));
             var profile = JsonConvert.DeserializeObject<Profile>(result);
 
             var aggresponse = new

--- a/Source/ApiGWs/Tailwind.Traders.Bff/Infrastructure/API.cs
+++ b/Source/ApiGWs/Tailwind.Traders.Bff/Infrastructure/API.cs
@@ -35,7 +35,7 @@ namespace Tailwind.Traders.MobileBff.Infrastructure
 
         public static class Profiles
         {
-            public static string GetProfile(string baseUri, string version, int userId) => $"{baseUri}/{version}/profile/{userId}";
+            public static string GetProfile(string baseUri, string version) => $"{baseUri}/{version}/profile/me";
             public static string GetProfiles(string baseUri, string version) => $"{baseUri}/{version}/profile";
         }
 

--- a/Source/ApiGWs/Tailwind.Traders.WebBff/Controllers/ProfilesController.cs
+++ b/Source/ApiGWs/Tailwind.Traders.WebBff/Controllers/ProfilesController.cs
@@ -40,14 +40,14 @@ namespace Tailwind.Traders.WebBff.Controllers
             return Ok(profiles);
         }
 
-        // GET: v1/profiles/id
-        [HttpGet("{userId}")]
+        // GET: v1/profiles/me
+        [HttpGet("me")]
         [ProducesResponseType((int)HttpStatusCode.OK)]
-        public async Task<IActionResult> GetProfile(int userId)
+        public async Task<IActionResult> GetProfile()
         {
             var client = _httpClientFactory.CreateClient(HttpClients.ApiGW);
 
-            var result = await client.GetStringAsync(API.Profiles.GetProfile(_settings.ProfileApiUrl, VERSION_API, userId));
+            var result = await client.GetStringAsync(API.Profiles.GetProfile(_settings.ProfileApiUrl, VERSION_API));
             var profile = JsonConvert.DeserializeObject<Profile>(result);
 
             result = await client.GetStringAsync(API.Coupons.GetCoupons(_settings.CouponsApiUrl, VERSION_API));
@@ -65,15 +65,15 @@ namespace Tailwind.Traders.WebBff.Controllers
             return Ok(aggresponse);
         }
 
-        // GET: v1/profiles/navbar/id
-        [HttpGet("navbar/{userId}")]
+        // GET: v1/profiles/navbar/me
+        [HttpGet("navbar/me")]
         [ProducesResponseType((int)HttpStatusCode.OK)]
-        public async Task<IActionResult> GetProfileNavBar(int userId)
+        public async Task<IActionResult> GetProfileNavBar()
         {
             var client = _httpClientFactory.CreateClient(HttpClients.ApiGW);
 
-            var result = await client.GetStringAsync(API.Profiles.GetProfile(_settings.ProfileApiUrl, VERSION_API, userId));
-            var profile = JsonConvert.DeserializeObject<Profile>(result);           
+            var result = await client.GetStringAsync(API.Profiles.GetProfile(_settings.ProfileApiUrl, VERSION_API));
+            var profile = JsonConvert.DeserializeObject<Profile>(result);
 
             var aggresponse = new
             {

--- a/Source/ApiGWs/Tailwind.Traders.WebBff/Infrastructure/API.cs
+++ b/Source/ApiGWs/Tailwind.Traders.WebBff/Infrastructure/API.cs
@@ -35,7 +35,7 @@ namespace Tailwind.Traders.WebBff.Infrastructure
 
         public static class Profiles
         {
-            public static string GetProfile(string baseUri, string version, int userId) => $"{baseUri}/{version}/profile/{userId}";
+            public static string GetProfile(string baseUri, string version) => $"{baseUri}/{version}/profile/me";
             public static string GetProfiles(string baseUri, string version) => $"{baseUri}/{version}/profile";
         }
 

--- a/Source/Services/Tailwind.Traders.Profile.Api/Controllers/ProfilesController.cs
+++ b/Source/Services/Tailwind.Traders.Profile.Api/Controllers/ProfilesController.cs
@@ -2,6 +2,7 @@
 using System.Collections.Generic;
 using System.Linq;
 using System.Net;
+using System.Security.Claims;
 using System.Threading.Tasks;
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
@@ -32,7 +33,7 @@ namespace Tailwind.Traders.Profile.Api.Controllers
         [HttpGet]
         [ProducesResponseType(typeof(List<Profiles>), (int)HttpStatusCode.OK)]
         [ProducesResponseType((int)HttpStatusCode.NoContent)]
-        public async Task<IActionResult> Get()
+        public async Task<IActionResult> GetAllProfiles()
         {
             var result = await _ctx.Profiles
                 .Select(p => p.ToProfileDto(_settings))
@@ -46,14 +47,15 @@ namespace Tailwind.Traders.Profile.Api.Controllers
             return Ok(result);
         }
 
-        // GET v1/profile/5
-        [HttpGet("{id}")]
+        // GET v1/profile/me
+        [HttpGet("me")]
         [ProducesResponseType(typeof(List<Profiles>), (int)HttpStatusCode.OK)]
         [ProducesResponseType((int)HttpStatusCode.BadRequest)]
-        public async Task<IActionResult> Get(int id)
+        public async Task<IActionResult> GetProfile()
         {
+            var userId = ((ClaimsIdentity)User.Identity).Claims.Single(claim => claim.Type == "emails").Value;
             var result = await _ctx.Profiles
-                .Where(p => p.Id == id)
+                .Where(p => p.Email == userId)
                 .Select(p => p.ToProfileDto(_settings))
                 .SingleOrDefaultAsync();
 


### PR DESCRIPTION
Change profile endpoint to identify the user by the email claim instead of user id. The profile API anf the BFF's have been modified to not use anymore the user id.

The PR modifies the URL for Get profiles, so this is a breaking changes for the Web amd mobile app.