### PR TITLE
updated AKS version to 1.12.8 because 1.12.5 is no longer supported

### DIFF
--- a/Deploy/deployment.json
+++ b/Deploy/deployment.json
@@ -17,7 +17,7 @@
     },
     "aksVersion": {
       "type": "string",
-      "defaultValue": "1.12.5"
+      "defaultValue": "1.12.8"
     },
     "pgversion": {
       "type": "string",


### PR DESCRIPTION
az aks get-versions -l eastus -o table

KubernetesVersion    Upgrades
-------------------  -----------------------
1.13.5               None available
1.12.8               1.13.5
1.12.7               1.12.8, 1.13.5
1.11.9               1.12.7, 1.12.8
1.11.8               1.11.9, 1.12.7, 1.12.8
1.10.13              1.11.8, 1.11.9
1.10.12              1.10.13, 1.11.8, 1.11.9