### PR TITLE
changed sdkTag to 2.2

### DIFF
--- a/Source/docker-compose.netcore22.yml
+++ b/Source/docker-compose.netcore22.yml
@@ -5,34 +5,34 @@ services:
     build:
       args:
         image: microsoft/dotnet-nightly
-        sdkTag: 2.2-sdk
+        sdkTag: 2.2
         runtimeTag: 2.2-aspnetcore-runtime
         coreversion: netcore22
   webapigw:
     build:
       args:
         image: microsoft/dotnet-nightly
-        sdkTag: 2.2-sdk
+        sdkTag: 2.2
         runtimeTag: 2.2-aspnetcore-runtime
         coreversion: netcore22
   image-classifier.api:
     build:
       args:
         image: microsoft/dotnet-nightly
-        sdkTag: 2.2-sdk
+        sdkTag: 2.2
         runtimeTag: 2.2-aspnetcore-runtime
         coreversion: netcore22
   product.api:
     build:
       args:
         image: microsoft/dotnet-nightly
-        sdkTag: 2.2-sdk
+        sdkTag: 2.2
         runtimeTag: 2.2-aspnetcore-runtime
         coreversion: netcore22        
   profile.api:
     build:
       args:
         image: microsoft/dotnet-nightly
-        sdkTag: 2.2-sdk
+        sdkTag: 2.2
         runtimeTag: 2.2-aspnetcore-runtime
         coreversion: netcore22     


### PR DESCRIPTION
ran into errors using the 2.2-sdk tag as it doesn't exist in the MCR as a label

ERROR: 
failed to build: manifest for mcr.microsoft.com/dotnet/core/sdk:2.2-sdk not found: manifest unknown: manifest unknown