### PR TITLE
Update for TLS/SSL scripts to user Helm 3 and cert-manager 0.14

### DIFF
--- a/Deploy/helm/tls-support/templates/certificate.yaml
+++ b/Deploy/helm/tls-support/templates/certificate.yaml
@@ -1,22 +1,15 @@
-apiVersion: certmanager.k8s.io/v1alpha1
+apiVersion: cert-manager.io/v1alpha2
 kind: Certificate
 metadata:
   name: {{ .Values.certName }}
   namespace: default
-  environment: {{ .Values.environment }}
-  app: {{ .Values.applicationName }}
+  labels:
+    environment: {{ .Values.environment }}
+    app: {{ .Values.applicationName }}
 spec:
   secretName: {{ .Values.certSecretName }}
   issuerRef:
     name: {{ .Values.issuerName }}
-    environment: {{ .Values.environment }}
-    app: {{ .Values.applicationName }}
   commonName: {{ .Values.domain }}
   dnsNames:
   - {{ .Values.domain }}
-  acme:
-    config:
-    - http01:
-        ingressClass: {{ .Values.ingressClass }}
-      domains:
-      - {{ .Values.domain }}

--- a/Deploy/helm/tls-support/templates/issuer.yaml
+++ b/Deploy/helm/tls-support/templates/issuer.yaml
@@ -1,14 +1,18 @@
-apiVersion: certmanager.k8s.io/v1alpha1
+apiVersion: cert-manager.io/v1alpha2
 kind: Issuer
 metadata:
   name: {{ .Values.issuerName }}
   namespace: default
-  environment: {{ .Values.environment }}
-  app: {{ .Values.applicationName }}
+  labels:
+    environment: {{ .Values.environment }}
+    app: {{ .Values.applicationName }}
 spec:
   acme:
     server: {{ .Values.server }}
     email: not@used.com
     privateKeySecretRef:
       name: {{ .Values.issuerSecretName }}
-    http01: {}
+    solvers:
+    - http01:
+        ingress:
+          class: {{ .Values.ingressClass }}

--- a/Deploy/powershell/Add-Cert-Manager.ps1
+++ b/Deploy/powershell/Add-Cert-Manager.ps1
@@ -1,4 +1,8 @@
 #! /usr/bin/pwsh
 
+# Adds the official cert-manager repository to your local and updates the repo cache
+Invoke-Expression "helm repo add jetstack https://charts.jetstack.io"
+Invoke-Expression "helm repo update"
+
 # Installs cert-manager on cluster
-Invoke-Expression "helm install --name cert-manager --namespace kube-system  --version v0.4.1 stable/cert-manager"
+Invoke-Expression "helm install cert-manager jetstack/cert-manager --namespace kube-system --version v0.13.1"

--- a/Deploy/powershell/Enable-Ssl.ps1
+++ b/Deploy/powershell/Enable-Ssl.ps1
@@ -75,12 +75,12 @@ Join-Path .. helm | Push-Location
 
 if ($sslSupport -eq "staging") {
     Write-Host "Adding TLS/SSL support using Let's Encrypt Staging environment" -ForegroundColor Yellow
-    Write-Host "helm install --name $name-ssl -f $(Join-Path tls-support values-staging.yaml) --set domain=$domain tls-support" -ForegroundColor Yellow
-    cmd /c "helm install --name $name-ssl-staging -f $(Join-Path tls-support values-staging.yaml) --set domain=$domain tls-support"
+    Write-Host "helm install $name-ssl -f $(Join-Path tls-support values-staging.yaml) --set domain=$domain tls-support" -ForegroundColor Yellow
+    cmd /c "helm install $name-ssl-staging -f $(Join-Path tls-support values-staging.yaml) --set domain=$domain tls-support"
 }
 if ($sslSupport -eq "prod") {
     Write-Host "Adding TLS/SSL support using Let's Encrypt PRODUCTION environment" -ForegroundColor Yellow
-    cmd /c "helm install --name $name-ssl-prod -f $(Join-Path tls-support values-prod.yaml) --set domain=$domain tls-support"
+    cmd /c "helm install $name-ssl-prod -f $(Join-Path tls-support values-prod.yaml) --set domain=$domain tls-support"
 }
 if ($sslSupport -eq "custom") {
     Write-Host "TLS support is custom bound to domain $domain" -ForegroundColor Yellow


### PR DESCRIPTION
Fix to the SSL/TLS scripts to support helm 3 and new versions of cert-manager following the suggestions in issue #83 .