### PR TITLE
Update Generate-Config.ps1 for PowerShell 7 compatibility

### DIFF
--- a/Deploy/powershell/Generate-Config.ps1
+++ b/Deploy/powershell/Generate-Config.ps1
@@ -66,10 +66,10 @@ else {
 }
 
 ## Getting App Insights instrumentation key, if required
-$appinsightsId=""
+$appinsightsId=@()
 $appInsightsName=$(az resource list -g $resourceGroup --resource-type Microsoft.Insights/components --query [].name | ConvertFrom-Json)
 if ($appInsightsName -and $appInsightsName.Length -eq 1) {
-    $appinsightsConfig=$(az monitor app-insights component show --app $appInsightsName[0] -g $resourceGroup -o json | ConvertFrom-Json)
+    $appinsightsConfig=$(az monitor app-insights component show --app $appInsightsName -g $resourceGroup -o json | ConvertFrom-Json)
 
     if ($appinsightsConfig) {
         $appinsightsId = $appinsightsConfig.instrumentationKey           


### PR DESCRIPTION
The issue is with the following line:
`if ($appInsightsName -and $appInsightsName.Length -eq 1) {`
 In PS 5 it seems the command returns an array, but in PS 7 it returns a string. 
The easiest fix seems to be to define the variable as an array instead of a string before the query.
`$appinsightsId=@()`
Also, since you are only executing the query for the app insights config if the array contains one element, the `[0]` isn't necessary and it runs fine without it, so for simplicy's sake I removed it.
I have tested with PowerShell 5.1 and PowerShell 7.0.3